### PR TITLE
Allowed drift when verifying tokens

### DIFF
--- a/spec/crotp/hotp_spec.cr
+++ b/spec/crotp/hotp_spec.cr
@@ -13,7 +13,7 @@ describe CrOTP::HOTP do
     "287922",
     "162583",
     "399871",
-    "520489"
+    "520489",
   ]
   secret = "12345678901234567890"
   hotp = CrOTP::HOTP.new(secret)
@@ -34,6 +34,10 @@ describe CrOTP::HOTP do
 
       it "does not verify the RFC example for the result with counter #{counter} + 1" do
         hotp.verify(result, counter + 1).should be_false
+      end
+
+      it "does verify the RFC example for the result with counter #{counter} + 1 and an allowed drift of 1" do
+        hotp.verify(result, counter + 1, allowed_drift: 1).should be_true
       end
     end
   end

--- a/spec/crotp/totp_spec.cr
+++ b/spec/crotp/totp_spec.cr
@@ -44,6 +44,10 @@ describe CrOTP::TOTP do
       it "does not verify the RFC example for the result with time #{time} + 1 minute" do
         totp.verify(result[2, 6], at: time + 60).should be_false
       end
+
+      it "verifies the example with time #{time} + 1 minute and an allowed drift of 2" do
+        totp.verify(result[2,6], at: time + 60, allowed_drift: 2).should be_true
+      end
     end
   end
 end

--- a/src/crotp/hotp.cr
+++ b/src/crotp/hotp.cr
@@ -9,8 +9,8 @@ module CrOTP
       generate_otp(counter)
     end
 
-    def verify(token : String, counter : Int) : Bool
-      verify_otp(token, counter)
+    def verify(token : String, counter : Int, allowed_drift : Int = 0) : Bool
+      Array.new(allowed_drift+1) { |i| verify_otp(token, counter - i) }.any?
     end
   end
 end

--- a/src/crotp/totp.cr
+++ b/src/crotp/totp.cr
@@ -14,13 +14,13 @@ module CrOTP
       generate(at.epoch)
     end
 
-    def verify(token : String, at : Int = Time.now.epoch) : Bool
+    def verify(token : String, at : Int = Time.now.epoch, allowed_drift : Int = 0) : Bool
       counter = at / 30
-      verify_otp(token, counter)
+      Array.new(allowed_drift+1) { |i| verify_otp(token, counter - i) }.any?
     end
 
-    def verify(token : String, at : Time) : Bool
-      verify(token, at.epoch)
+    def verify(token : String, at : Time, allowed_drift : Int = 0) : Bool
+      verify(token, at.epoch, allowed_drift)
     end
   end
 end


### PR DESCRIPTION
Allows you to verify across a window of periods/counters.

e.g.

```crystal
secret = "hello"
totp = CrOTP::TOTP.new(secret)
token = totp.generate()
sleep(30)
totp.verify(token)
# => false
totp.verify(token, allowed_drift: 1)
# => true
```

Fixes #3.